### PR TITLE
Understand server response errors

### DIFF
--- a/MIGRATION_INSTRUCTIONS.md
+++ b/MIGRATION_INSTRUCTIONS.md
@@ -1,0 +1,66 @@
+# Migration Instructions: Fix User Creation Issue
+
+## Problem
+The application is experiencing the following errors:
+- 403 Forbidden when trying to access user data
+- Foreign key constraint violation when creating templates
+- Users are not being created in the `users` table after authentication
+
+## Solution
+We've created a migration that:
+1. Adds the missing RLS policy for user insertion
+2. Creates a function to ensure users exist before operations
+3. Updates the template creation process to use proper permissions
+
+## Steps to Apply the Migration
+
+### 1. Access Supabase Dashboard
+Go to your Supabase project dashboard at https://app.supabase.com
+
+### 2. Navigate to SQL Editor
+Click on "SQL Editor" in the left sidebar
+
+### 3. Execute the Migration
+Copy and paste the entire contents of `/workspace/supabase/fix-user-creation.sql` into the SQL editor and click "Run"
+
+### 4. Verify the Migration
+After running the migration, verify that:
+- The new policies are created
+- The functions `ensure_user_exists`, `ensure_current_user_exists`, and updated `create_user_template` exist
+- No errors were reported during execution
+
+### 5. Test the Application
+1. Clear your browser's local storage and cookies for the application
+2. Sign out if you're currently signed in
+3. Sign in again with Google authentication
+4. Try creating a new template - it should work without errors
+
+## What Changed in the Code
+
+### Database Changes
+- Added `Users can insert own profile` policy to allow users to create their own records
+- Created `ensure_user_exists()` function that safely creates user records
+- Updated `create_user_template()` to call `ensure_user_exists()` first
+- Created `ensure_current_user_exists()` RPC function for client-side calls
+
+### Application Code Changes
+- Updated `databaseService.ts` to use the RPC function instead of direct insertion
+- Updated `AuthContext.tsx` to ensure users exist when they authenticate
+
+## Rollback (if needed)
+If you need to rollback these changes:
+
+```sql
+-- Drop the new policies and functions
+DROP POLICY IF EXISTS "Users can insert own profile" ON public.users;
+DROP FUNCTION IF EXISTS public.ensure_user_exists();
+DROP FUNCTION IF EXISTS public.ensure_current_user_exists();
+
+-- Restore original create_user_template function
+-- (Copy from your original supabase-setup.sql file)
+```
+
+## Additional Notes
+- This migration is safe to run multiple times
+- Existing users will not be affected
+- The migration ensures backward compatibility

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { auth, type AuthUser } from '@/lib/supabase';
+import { auth, supabase, type AuthUser } from '@/lib/supabase';
 import type { Session } from '@supabase/supabase-js';
 
 interface AuthContextType {
@@ -30,6 +30,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [mounted, setMounted] = useState(false);
 
   const isAuthenticated = user !== null && session !== null;
+
+  // Función para asegurar que el usuario existe en la base de datos
+  const ensureUserExists = async () => {
+    try {
+      const { error } = await supabase.rpc('ensure_current_user_exists');
+      if (error) {
+        console.error('Error al asegurar que el usuario existe:', error);
+      }
+    } catch (err) {
+      console.error('Error al verificar usuario:', err);
+    }
+  };
 
   useEffect(() => {
     // Verificar que estamos en el cliente
@@ -68,6 +80,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
               updated_at: session.user.updated_at,
             });
             setError(null);
+            // Asegurar que el usuario existe en la base de datos
+            await ensureUserExists();
           }
         }
       } catch (err) {
@@ -96,6 +110,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           updated_at: session.user.updated_at,
         });
         setError(null);
+        // Asegurar que el usuario existe en la base de datos
+        await ensureUserExists();
       } else {
         setUser(null);
         if (event === 'SIGNED_OUT') {

--- a/src/lib/services/databaseService.ts
+++ b/src/lib/services/databaseService.ts
@@ -234,10 +234,14 @@ export const userTemplatesService = {
   // Crear una nueva plantilla personalizada
   createUserTemplate: async (userTemplate: Omit<UserTemplate, 'id' | 'created_at' | 'updated_at'>): Promise<UserTemplate> => {
     // Asegurarse de que el usuario exista en la tabla `users` para evitar errores de clave foránea
-    // En algunos flujos de autenticación el registro puede no existir todavía.
-    await supabase
-      .from('users')
-      .upsert({ id: userTemplate.user_id }, { onConflict: 'id' });
+    // Usar la función RPC que tiene los permisos necesarios
+    const { error: ensureError } = await supabase
+      .rpc('ensure_current_user_exists');
+    
+    if (ensureError) {
+      console.error('Error al asegurar que el usuario existe:', ensureError);
+      throw ensureError;
+    }
 
     const { data, error } = await supabase
       .from('user_templates')

--- a/supabase/fix-user-creation.sql
+++ b/supabase/fix-user-creation.sql
@@ -1,0 +1,95 @@
+-- Fix for user creation and template creation issues
+-- This migration adds missing policies and ensures users can be created properly
+
+-- Drop existing policy if it exists
+DROP POLICY IF EXISTS "Users can insert own profile" ON public.users;
+
+-- Create policy to allow users to insert their own record
+CREATE POLICY "Users can insert own profile" ON public.users
+  FOR INSERT WITH CHECK (auth.uid() = id);
+
+-- Function to ensure user exists before any operation
+CREATE OR REPLACE FUNCTION public.ensure_user_exists()
+RETURNS void AS $$
+DECLARE
+  user_auth_id uuid;
+  user_email text;
+  user_metadata jsonb;
+BEGIN
+  -- Get the current user's auth ID
+  user_auth_id := auth.uid();
+  
+  IF user_auth_id IS NULL THEN
+    RAISE EXCEPTION 'No authenticated user';
+  END IF;
+  
+  -- Get user metadata from auth.users
+  SELECT email, raw_user_meta_data 
+  INTO user_email, user_metadata
+  FROM auth.users 
+  WHERE id = user_auth_id;
+  
+  -- Insert user if it doesn't exist
+  INSERT INTO public.users (id, email, name, image, phone_number)
+  VALUES (
+    user_auth_id, 
+    user_email,
+    COALESCE(user_metadata->>'full_name', user_metadata->>'name'),
+    user_metadata->>'avatar_url',
+    user_metadata->>'phone_number'
+  )
+  ON CONFLICT (id) DO UPDATE SET
+    email = EXCLUDED.email,
+    name = COALESCE(EXCLUDED.name, public.users.name),
+    image = COALESCE(EXCLUDED.image, public.users.image),
+    updated_at = now();
+    
+  -- Create default template if needed
+  PERFORM public.create_default_user_template(user_auth_id);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Update the create_user_template function to ensure user exists
+CREATE OR REPLACE FUNCTION public.create_user_template(
+    template_name text,
+    template_content text
+)
+RETURNS uuid AS $$
+DECLARE
+    new_template_id uuid;
+    template_count integer;
+BEGIN
+    -- Ensure user exists first
+    PERFORM public.ensure_user_exists();
+    
+    -- Count existing templates
+    SELECT COUNT(*) INTO template_count 
+    FROM public.user_templates 
+    WHERE user_id = auth.uid();
+    
+    -- Generate name if not provided
+    IF template_name IS NULL OR template_name = '' THEN
+        template_name := 'Plantilla ' || (template_count + 1)::text;
+    END IF;
+    
+    -- Create the new template
+    INSERT INTO public.user_templates (name, content, user_id, is_active)
+    VALUES (template_name, template_content, auth.uid(), true)
+    RETURNING id INTO new_template_id;
+    
+    RETURN new_template_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Create RPC function to ensure user exists (can be called from client)
+CREATE OR REPLACE FUNCTION public.ensure_current_user_exists()
+RETURNS void AS $$
+BEGIN
+  PERFORM public.ensure_user_exists();
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Grant execute permissions
+GRANT EXECUTE ON FUNCTION public.ensure_user_exists() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.ensure_current_user_exists() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_user_template(text, text) TO authenticated;


### PR DESCRIPTION
Ensure user records exist in the database upon authentication and before creating templates to resolve foreign key constraint errors.

The application was failing to create templates due to foreign key constraint violations (`Key is not present in table "users"`). This occurred because user records were not consistently being created in the `users` table during the authentication flow, or due to restrictive Row Level Security (RLS) policies preventing direct insertion. This PR introduces a secure mechanism to ensure the `users` table is populated for authenticated users and updates the template creation logic to rely on this, preventing future foreign key errors.